### PR TITLE
Alterar texto

### DIFF
--- a/template/pages/app/index.ejs
+++ b/template/pages/app/index.ejs
@@ -76,7 +76,7 @@ const logo = _.settings.logo
         <input class="form-check-input" type="checkbox" name="checkModal" id="check-cart" value="accept" onclick="checkConfirm();">
         <label class="form-check-label" for="check-cart">
           <a href="javascript:;" data-toggle="modal" data-target="#modal-check" style="color: #000;">
-           Aceitar termos para <b>finalizar compra</b>, clicando aqui
+           Antes de<b>finalizar a compra</b>clique para aceitar termos e marque a caixinha
           </a>
         </label>
       </div>


### PR DESCRIPTION
Por favor, achei melhor o texto assim:  "Antes de finalizar a compra,clique para aceitar termos e marque a caixinha
. E a caixinha, no mobile (Samsung A51 no Brave) está deslocada acima e à direita.
![Screenshot_20221215_204601](https://user-images.githubusercontent.com/32439324/208072630-ef8f3491-831f-43e3-964a-7963fa9f4403.jpg)
